### PR TITLE
Display context-dependend content on status page

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -10,4 +10,20 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+
+    /**
+     * Indicates weather routes in this controller are in sharing mode.
+     *
+     * @var boolean
+     */
+    protected $sharingMode = false;
+
+
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct()
+    {
+        view()->share(['sharingMode' => $this->sharingMode]);
+    }
 }

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -12,7 +12,7 @@ class Controller extends BaseController
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
 
     /**
-     * Indicates weather routes in this controller are in sharing mode.
+     * Indicates wether the application operates in sharing mode.
      *
      * @var boolean
      */

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -19,7 +19,6 @@ class HomeController extends Controller
      * Create a new controller instance.
      *
      * @param PullRequestChecker $checker
-     * @internal param PullRequestChecker $prChecker
      */
     public function __construct(PullRequestChecker $checker)
     {
@@ -34,22 +33,22 @@ class HomeController extends Controller
      */
     public function index()
     {
-        if (Auth::check()) {
-            $user = Auth::user();
-            $prs = $this->checker->getQualifiedPullRequests($user);
-
-            $message = "I'm about to start hacking for Hacktoberfest!";
-
-            if ($prs->total_count > 0) {
-                $message = "I've completed $prs->total_count pull requests for Hacktoberfest!";
-            }
-
-            $viewData = compact('user', 'prs', 'message');
-            $viewData['sharingMode'] = $this->sharingMode;
-
-            return view('status', $viewData);
+        if (!Auth::check()) {
+            return view('index');
         }
 
-        return view('index');
+        $user = Auth::user();
+        $prs = $this->checker->getQualifiedPullRequests($user);
+
+        $message = "I'm about to start hacking for Hacktoberfest!";
+
+        if ($prs->total_count > 0) {
+            $message = "I've completed $prs->total_count pull requests for Hacktoberfest!";
+        }
+
+        $viewData = compact('user', 'prs', 'message');
+        $viewData['sharingMode'] = $this->sharingMode;
+
+        return view('status', $viewData);
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -9,8 +9,11 @@ class HomeController extends Controller
 {
     /**
      * Instance of the 'pull request checker'.
+     *
+     * @var PullRequestChecker
      */
     protected $checker;
+
 
     /**
      * Create a new controller instance.
@@ -33,15 +36,18 @@ class HomeController extends Controller
     {
         if (Auth::check()) {
             $user = Auth::user();
-
             $prs = $this->checker->getQualifiedPullRequests($user);
 
             $message = "I'm about to start hacking for Hacktoberfest!";
+
             if ($prs->total_count > 0) {
                 $message = "I've completed $prs->total_count pull requests for Hacktoberfest!";
             }
 
-            return view('status', compact('user', 'prs', 'message'));
+            $viewData = compact('user', 'prs', 'message');
+            $viewData['sharingMode'] = $this->sharingMode;
+
+            return view('status', $viewData);
         }
 
         return view('index');

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -8,18 +8,38 @@ use App\User;
 class ShareController extends Controller
 {
     /**
+     * Instance of the 'pull request checker'.
+     *
+     * @var PullRequestChecker
+     */
+    protected $checker;
+
+    /**
+     * Instance of user model.
+     *
+     * @var User
+     */
+    protected $user;
+
+    /**
      * Indicates wether routes in this controller are in sharing mode.
      *
      * @var boolean
      */
     protected $sharingMode = true;
 
+
     /**
      * Create a new controller instance.
+     *
+     * @param PullRequestChecker $checker
      */
-    public function __construct()
+    public function __construct(PullRequestChecker $checker, User $user)
     {
+        $this->checker     = $checker;
+        $this->user        = $user;
         $this->sharingMode = true;
+
         parent::__construct();
     }
 
@@ -27,19 +47,19 @@ class ShareController extends Controller
      * Display a user's PR status if user already authorized this app,
      * otherwise redirect to home page.
      *
-     * @param PullRequestChecker $checker
-     * @param $github_username
+     * @param string $github_username
+     *
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\View\View
      */
-    public function index(PullRequestChecker $checker, $github_username)
+    public function index($github_username)
     {
-        $user = User::where('github_username', '=', $github_username)->first();
+        $user = $this->user->where('github_username', '=', $github_username)->first();
 
         if (!$user) {
             return redirect('/');
         }
 
-        $prs = $checker->getQualifiedPullRequests($user);
+        $prs = $this->checker->getQualifiedPullRequests($user);
 
         $viewData = compact('user', 'prs');
         $viewData['sharingMode'] = $this->sharingMode;

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -8,6 +8,22 @@ use App\User;
 class ShareController extends Controller
 {
     /**
+     * Indicates wether routes in this controller are in sharing mode.
+     *
+     * @var boolean
+     */
+    protected $sharingMode = true;
+
+    /**
+     * Create a new controller instance.
+     */
+    public function __construct()
+    {
+        $this->sharingMode = true;
+        parent::__construct();
+    }
+
+    /**
      * Display a user's PR status if user already authorized this app,
      * otherwise redirect to home page.
      *
@@ -25,6 +41,9 @@ class ShareController extends Controller
 
         $prs = $checker->getQualifiedPullRequests($user);
 
-        return view('status', compact('user', 'prs'));
+        $viewData = compact('user', 'prs');
+        $viewData['sharingMode'] = $this->sharingMode;
+
+        return view('status', $viewData);
     }
 }

--- a/app/Http/Controllers/ShareController.php
+++ b/app/Http/Controllers/ShareController.php
@@ -21,13 +21,6 @@ class ShareController extends Controller
      */
     protected $user;
 
-    /**
-     * Indicates wether routes in this controller are in sharing mode.
-     *
-     * @var boolean
-     */
-    protected $sharingMode = true;
-
 
     /**
      * Create a new controller instance.

--- a/resources/views/status.blade.php
+++ b/resources/views/status.blade.php
@@ -5,7 +5,13 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <title>Hacktoberfest Status Tracker</title>
+        @if ($sharingMode)
+            <meta property="og:title" content="Hacktoberfest Status of {{ $user->name }}" />
+            <meta property="og:description" content="On this page you can see the Hacktoberfest stats of {{ $user->name }}." />
+            <meta property="og:image" content="https://nyc3.digitaloceanspaces.com/hacktoberfest/Hacktoberfest17-TWFB-02.png" />
+        @endif
+
+        <title>{{ $sharingMode ? 'Hacktoberfest Status of ' . $user->name : 'Hacktoberfest Status Tracker' }}</title>
 
         <style>
             {!! file_get_contents(public_path('css/preload.css')) !!}
@@ -25,7 +31,13 @@
                 <div class="container__content centered">
                     <img src="{{ asset('images/logo.svg') }}" alt="Hacktoberfest Logo">
 
-                    <p class="mb-30 mt-30 description">This little tool helps you to track your <a href="https://hacktoberfest.digitalocean.com/">Hacktoberfest</a> status. Below you can see how far you have already come.</p>
+                    <p class="mb-30 mt-30 description">
+                    @if ($sharingMode)
+                        These are the <a href="https://hacktoberfest.digitalocean.com/">Hacktoberfest</a> stats of {{ $user->name }}.
+                    @else
+                        This little tool helps you to track your <a href="https://hacktoberfest.digitalocean.com/">Hacktoberfest</a> status. Below you can see how far you have already come.
+                    @endif
+                    </p>
 
                     <div class="user">
                         <img class="user__img" src="{{ $user->github_avatar }}" title="{{ $user->name }}" width="84">
@@ -57,25 +69,31 @@
             <div class="container content">
                 @if ($prs->total_count == 0)
                     <div class="centered">
-                        <h2 class="mb-0">Seems like you didn't even start yet.</h2>
-                        <p class="description">
-                            Why don't you get yourself some inspiration on the <a href="https://hacktoberfest.digitalocean.com/">Hacktoberfest website</a>?
-                        </p>
+                        @if ($sharingMode)
+                            {{ $user->name }} hasn’t started yet. Sorry, nothing too see here.
+                        @else
+                            <h2 class="mb-0">Seems like you didn't even start yet.</h2>
+                            <p class="description">
+                                Why don't you get yourself some inspiration on the <a href="https://hacktoberfest.digitalocean.com/">Hacktoberfest website</a>?
+                            </p>
+                        @endif
                     </div>
                 @else
-                    @if ($prs->total_count >= 4)
-                        <h2 class="mb-0 centered">Congrats, you're done!</h2>
-                    @elseif ($prs->total_count == 1)
-                        <h2 class="mb-0 centered">A good start, just keep doing.</h2>
-                    @elseif ($prs->total_count == 2)
-                        <h2 class="mb-0 centered">Half-time, keep doing.</h2>
+                    @if (!$sharingMode)
+                        @if ($prs->total_count >= 4)
+                            <h2 class="mb-0 centered">Congrats, you're done!</h2>
+                        @elseif ($prs->total_count == 1)
+                            <h2 class="mb-0 centered">A good start, just keep doing.</h2>
+                        @elseif ($prs->total_count == 2)
+                            <h2 class="mb-0 centered">Half-time, keep doing.</h2>
+                        @else
+                        <h2 class="mb-0 centered">You're almost done.</h2>
+                        @endif
+                        <p class="description centered">Your qualified pull requests:</p>
                     @else
-                      <h2 class="mb-0 centered">You're almost done.</h2>
+                        <h3 class="mb-0 centered">{{ $user->name }}’s qualified pull requests:</h3>
                     @endif
 
-                    <p class="description centered">
-                        Your qualified pull requests:
-                    </p>
                     <div class="summary">
                         <ul class="summary__list">
                             @foreach ($prs->items as $item)

--- a/tests/IndexPageTest.php
+++ b/tests/IndexPageTest.php
@@ -1,19 +1,58 @@
 <?php
-
-use Illuminate\Foundation\Testing\WithoutMiddleware;
+use App\User;
+use App\Hacktoberfest\GitHub\PullRequestChecker;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
 
+/**
+ * Integration tests for the home page.
+ */
 class IndexPageTest extends TestCase
 {
-    /** @test */
-    public function index_page_contains_meta_and_og_tags()
+    /**
+     * Tests that the index page contains the expected content when visited anonymously.
+     */
+    public function testIndexUnregistered()
     {
+        Auth::shouldReceive('check')
+            ->andReturn(false);
+
         $this->visit('/')
+            ->see('Authenticate using GitHub')
             ->see('meta name="keywords"')
             ->see('meta name="description"')
             ->see('meta property="og:title"')
             ->see('meta property="og:description"')
             ->see('meta property="og:image"');
+    }
+
+    /**
+     * Tests that index() returns the status view without meta og tags if visited by an authenticated user.
+     */
+    public function testIndexAuthenticated()
+    {
+        $user = new User([
+            'name'         => 'TestUser',
+            'github_name'  => 'test_user',
+            'github_token' => 'foobar',
+        ]);
+
+        $pullRequestChecker = Mockery::mock(PullRequestChecker::class);
+        $pullRequestChecker->shouldReceive('getQualifiedPullRequests')
+            ->once()
+            ->andReturn($this->buildFakePullRequestData(2));
+
+        $this->app->instance(PullRequestChecker::class, $pullRequestChecker);
+
+        Auth::shouldReceive('check')
+            ->andReturn(true);
+
+        Auth::shouldReceive('user')
+            ->andReturn($user);
+
+        $this->visit('/')
+            ->dontSee('meta property="og:')
+            ->see('Sign out');
     }
 }

--- a/tests/StatusPageTest.php
+++ b/tests/StatusPageTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use App\Hacktoberfest\GitHub\PullRequestChecker;
+use App\Http\Controllers\HomeController;
+use App\User;
+use Auth;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+
+class StatusPageTest extends TestCase
+{
+    /**
+     * Verify that the shared status page has meta/og tags.
+     */
+    public function testSharedStatusPageHasMetaOg()
+    {
+        $this->visit('/Tardog')
+            ->see('meta property="og:');
+    }
+
+    /**
+     * Verify that the status page has no meta/og tags if visited by an authenticated user.
+     */
+    public function testNoMetaOgOnAuthenticatedStatusPage()
+    {
+        $user = new User([
+            'name'         => 'TestUser',
+            'github_name'  => 'test_user',
+            'github_token' => 'foobar',
+        ]);
+
+        $this->be($user);
+
+        $pullRequestCheckerMock = $this->createMock(PullRequestChecker::class);
+        $pullRequestCheckerMock->expects($this->once())
+            ->method('getQualifiedPullRequests')
+            ->willReturn($this->buildFakePullRequestData(2));
+
+        $controller = new HomeController($pullRequestCheckerMock);
+
+        $view    = $controller->index();
+        $content = $view->render();
+
+        $this->assertNotContains('meta property="og:', $content);
+    }
+
+    /**
+     * Create fake pull request data matching the format expected by the Github API.
+     *
+     * @param  integer $count
+     * @return object
+     */
+    protected function buildFakePullRequestData($count)
+    {
+        $fakeRepo            = new stdClass();
+        $fakeRepo->html_url  = 'https://github.com/NotARealRepo';
+        $fakeRepo->full_name = 'NotARealRepo';
+        $fakeRepo->name      = 'NotARealRepo';
+
+        $pullRequests                     = new stdClass();
+        $pullRequests->total_count        = $count;
+        $pullRequests->incomplete_results = false;
+        $pullRequests->items              = [];
+
+        for ($i=0; $i < $count; $i++) { 
+            $fakePr             = new stdClass();
+            $fakePr->html_url   = 'https://github.com/NotARealRepo';
+            $fakePr->title      = 'Test PR';
+            $fakePr->repo       = $fakeRepo;
+            $fakePr->created_at = '2017-10-01T00:00:00Z';
+            $fakePr->body       = '';
+            
+            $pullRequests->items[] = $fakePr;
+        }
+
+        return $pullRequests;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,4 +1,6 @@
 <?php
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
 
 abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
@@ -8,6 +10,7 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
      * @var string
      */
     protected $baseUrl = 'http://localhost';
+
 
     /**
      * Creates the application.
@@ -21,5 +24,57 @@ abstract class TestCase extends Illuminate\Foundation\Testing\TestCase
         $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 
         return $app;
+    }
+
+    /**
+     * Mock a collection with first() returning the given result.
+     *
+     * @param mixed $result
+     *
+     * @return Collection
+     */
+    protected function createCollectionMockWithFirst($result)
+    {
+        $collection = Mockery::mock(Collection::class);
+        $collection->shouldReceive('first')
+            ->andReturn($result);
+
+        return $collection;
+    }
+
+    /**
+     * Creates fake pull request data matching the format returned by the Github
+     * API.
+     *
+     * @param integer  $count  The amount of pull requests to generate.
+     *
+     * @return object
+     */
+    protected function buildFakePullRequestData($count)
+    {
+        $now = new Carbon();
+
+        $fakeRepo            = new stdClass();
+        $fakeRepo->html_url  = 'https://github.com/NotARealRepo';
+        $fakeRepo->full_name = 'NotARealRepo';
+        $fakeRepo->name      = 'NotARealRepo';
+
+        $pullRequests                     = new stdClass();
+        $pullRequests->total_count        = $count;
+        $pullRequests->incomplete_results = false;
+        $pullRequests->items              = [];
+
+        for ($i=0; $i < $count; $i++) {
+            $fakePr             = new stdClass();
+            $fakePr->html_url   = 'https://github.com/NotARealRepo';
+            $fakePr->title      = 'Test PR';
+            $fakePr->repo       = $fakeRepo;
+            $fakePr->created_at = $now->toDateTimeString();
+            $fakePr->body       = '';
+
+            $pullRequests->items[] = $fakePr;
+        }
+
+        return $pullRequests;
     }
 }


### PR DESCRIPTION
This resolves #23. With these changes, the shared status page presents slightly different content than the status page served to authenticated users.

I also added tests for the new status page distinctions and did some refactoring on the existing ones to better check for different application states depending on authentication status.